### PR TITLE
Fix login issue for Nissan North America

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ leaf2mqtt is packaged as a container. This is an automatically published / updat
 
 ##### Example:
 ```
-docker run --restart always -e LEAF_USERNAME="myusername@somewhere.com" -e LEAF_PASSWORD="Some P4ssword!" -e LEAF_TYPE="newerThanMay2019" -e MQTT_HOST=192.168.1.111 -e UPDATE_INTERVAL_MINUTES=1440 --name leaf2mqtt ghcr.io/k8s-at-home/leaf2mqtt:latest
+docker run --restart always -e LEAF_USERNAME="myusername@somewhere.com" -e LEAF_PASSWORD="Some P4ssword!" -e LEAF_TYPE="newerThanMay2019" -e MQTT_HOST=192.168.1.111 -e UPDATE_INTERVAL_MINUTES=1440  -e USER_AGENT='NissanLeaf/7.2.4 CFNetwork/1312 Darwin/21.0.0' --name leaf2mqtt ghcr.io/k8s-at-home/leaf2mqtt:latest
 ```
 
 :information_source: The `CHARGING_UPDATE_INTERVAL_MINUTES` value will only be used after the ongoing `UPDATE_INTERVAL_MINUTES` is elapsed and the Leaf is charging.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,33 +36,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  dartcarwings:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "405a89ed99fa296ea3dae0e72b6636bea50738bd"
-      url: "https://github.com/Tobiaswk/dartcarwings"
-    source: git
-    version: "1.0.0"
-  dartnissanconnect:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "2a5b7e449fb0762712cc17fea75c703182708323"
-      url: "https://github.com/Tobiaswk/dartnissanconnect"
-    source: git
-    version: "1.0.0"
-  dartnissanconnectna:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "902946e38daabd60e08ddd4c93fcdaefa418fb07"
-      url: "https://github.com/Tobiaswk/dartnissanconnectna"
-    source: git
-    version: "1.0.0"
   event_bus:
     dependency: transitive
     description:

--- a/src/leaf/leaf_session.dart
+++ b/src/leaf/leaf_session.dart
@@ -16,18 +16,18 @@ enum LeafType {
 }
 
 class LeafSessionFactory {
-  static LeafSession createLeafSession(LeafType leafType, String username, String password) {
+  static LeafSession createLeafSession(LeafType leafType, String username, String password, String userAgent) {
     switch (leafType) {
       case LeafType.newerThanMay2019:
         return NissanConnectSessionWrapper(username, password);
         break;
 
       case LeafType.olderCanada:
-        return NissanConnectNASessionWrapper('CA', username, password);
+        return NissanConnectNASessionWrapper('CA', username, password, userAgent);
         break;
 
       case LeafType.olderUsa:
-        return NissanConnectNASessionWrapper('US', username, password);
+        return NissanConnectNASessionWrapper('US', username, password, userAgent);
         break;
 
       default:

--- a/src/leaf/nissan_connect_na_wrapper.dart
+++ b/src/leaf/nissan_connect_na_wrapper.dart
@@ -11,17 +11,18 @@ final Logger _log = Logger('NissanConnectNASessionWrapper');
 
 class NissanConnectNASessionWrapper extends LeafSessionInternal {
   NissanConnectNASessionWrapper(
-      this._countryCode, String username, String password)
+      this._countryCode, String username, String password, this._userAgent)
       : super(username, password);
 
   NissanConnectSession _session;
   final String _countryCode;
+  final String _userAgent;
 
   @override
   Future<void> login() async {
     _session = NissanConnectSession(debug: _log.level <= Level.FINER);
     await _session.login(
-        username: username, password: password, countryCode: _countryCode, userAgent: 'NissanLeaf/7.2.4 CFNetwork/1312 Darwin/21.0.0');
+        username: username, password: password, countryCode: _countryCode, userAgent: _userAgent);
 
     final List<VehicleInternal> newVehicles = _session.vehicles
         .map((NissanConnectVehicle vehicle) =>

--- a/src/leaf/nissan_connect_na_wrapper.dart
+++ b/src/leaf/nissan_connect_na_wrapper.dart
@@ -21,7 +21,7 @@ class NissanConnectNASessionWrapper extends LeafSessionInternal {
   Future<void> login() async {
     _session = NissanConnectSession(debug: _log.level <= Level.FINER);
     await _session.login(
-        username: username, password: password, countryCode: _countryCode);
+        username: username, password: password, countryCode: _countryCode, userAgent: 'NissanLeaf/7.2.4 CFNetwork/1312 Darwin/21.0.0');
 
     final List<VehicleInternal> newVehicles = _session.vehicles
         .map((NissanConnectVehicle vehicle) =>

--- a/src/leaf_2_mqtt.dart
+++ b/src/leaf_2_mqtt.dart
@@ -34,6 +34,7 @@ Future<void> main() async {
 
   final String leafUser = envVars['LEAF_USERNAME'];
   final String leafPassword = envVars['LEAF_PASSWORD'];
+  final String userAgent = envVars['USER_AGENT'];
 
   if ((leafUser?.isEmpty ?? true) || (leafPassword?.isEmpty ?? true)) {
     _log.severe(
@@ -55,7 +56,7 @@ Future<void> main() async {
   }
 
   _session =
-      LeafSessionFactory.createLeafSession(leafType, leafUser, leafPassword);
+      LeafSessionFactory.createLeafSession(leafType, leafUser, leafPassword, userAgent);
 
   await _login();
 


### PR DESCRIPTION
Added USER_AGENT env var support and passing it to the NA library. Maybe no need to lock the dartnissan* libs? If they're locked just need to use the latest as of a few days ago when userAgent was added to the North America lib. 

